### PR TITLE
Use ConnectionCustomizer to ensure login is only done when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ let slot = slots.first().unwrap();
 let session_auth = SessionAuth::RwUser(AuthPin::new("fedcba".to_string()));
 let manager = SessionManager::new(pkcs11, *slot, &session_auth);
 
-let pool = let pool_builder = Pool::builder().connection_customizer(session_auth.into_customizer()).unwrap();
+let pool_builder = Pool::builder().connection_customizer(session_auth.into_customizer());
+let pool = pool_builder.build(manager).unwrap();
 
 let session = pool.get().unwrap();
 println!("{:?}", session.get_session_info().unwrap());

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 
 Session pool manager for [cryptoki](https://github.com/parallaxsecond/rust-cryptoki/).
 
+Cryptoki has a single login state for all sessions.
+Only when all sessions are closed, a login is needed again.
+This library requires a `ConnectionCustomizer` on the pool to ensure login is only done when needed.
+The `SessionAuth` can be converted into the appropriate `ConnectionCustomizer`.
+
 ## Example
 
 ```rust no_run
@@ -14,9 +19,10 @@ let pkcs11 = Pkcs11::new("libsofthsm2.so").unwrap();
 pkcs11.initialize(CInitializeArgs::OsThreads).unwrap();
 let slots = pkcs11.get_slots_with_token().unwrap();
 let slot = slots.first().unwrap();
-let manager = SessionManager::new(pkcs11, *slot, SessionType::RwUser(AuthPin::new("fedcba".to_string())));
+let session_auth = SessionAuth::RwUser(AuthPin::new("fedcba".to_string()));
+let manager = SessionManager::new(pkcs11, *slot, &session_auth);
 
-let pool = r2d2::Pool::builder().build(manager).unwrap();
+let pool = let pool_builder = Pool::builder().connection_customizer(session_auth.into_customizer()).unwrap();
 
 let session = pool.get().unwrap();
 println!("{:?}", session.get_session_info().unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,7 @@ impl SessionManager {
     /// ```
     pub fn max_size(&self, maximum: u32) -> Result<Option<u32>, cryptoki::error::Error> {
         let token_info = self.pkcs11.get_token_info(self.slot)?;
-        let limit = match self.session_type {
-            SessionType::RoPublic | SessionType::RoUser(_) => token_info.max_session_count(),
-            SessionType::RwPublic | SessionType::RwUser(_) | SessionType::RwSecurityOfficer(_) => {
-                token_info.max_session_count()
-            }
-        };
+        let limit = token_info.max_session_count();
         let res = match limit {
             Limit::Max(m) => Some(m.try_into().unwrap_or(u32::MAX)),
             Limit::Unavailable => None,


### PR DESCRIPTION
This solves the problem of the multiple Login calls. There does not seem a way to force a specific `ConnectionCustomizer` on the pool, but I guess users will find out soon enough if their login does not work.

Note that the TODO comment was slightly incorrect. When a `Session` is dropped, cryptoki does *not* do a `Logout`, but it simply does a `CloseSession`. When all sessions are closed, you need to login again.

I did some extensive testing with our Utimaco CryptoServer library. It seems to work, even when reconnecting in the library.